### PR TITLE
Fix: passing empty request details for bulk-export

### DIFF
--- a/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/ExpandResourceAndWriteBinaryStep.java
+++ b/hapi-fhir-storage-batch2-jobs/src/main/java/ca/uhn/fhir/batch2/jobs/export/ExpandResourceAndWriteBinaryStep.java
@@ -528,7 +528,7 @@ public class ExpandResourceAndWriteBinaryStep
 				// Make sure we don't accidentally reuse an ID. This should be impossible given the
 				// amount of entropy in the IDs but might as well be sure.
 				try {
-					IBaseBinary output = binaryDao.read(binary.getIdElement(), new SystemRequestDetails(), true);
+					IBaseBinary output = binaryDao.read(binary.getIdElement(), srd, true);
 					if (output != null) {
 						continue;
 					}


### PR DESCRIPTION
## Background
When running a bulk‐export ($export) against a partitioned HAPI FHIR server, the export job fails in the “write to binaries” step with:
```
HAPI-1319: No interceptor provided a value for pointcut: STORAGE_PARTITION_IDENTIFY_READ and STORAGE_PARTITION_IDENTIFY_ANY
```

Root cause: the collision‐check and final binaryDao.update(...) calls in NdJsonResourceWriter use a brand‐new SystemRequestDetails() (with no partition info), so the partition‐identification interceptor can’t resolve which tenant to read/write under.


## Updates
In NdJsonResourceWriter.accept(...):
1. Replace the new SystemRequestDetails() with the request details with partition information.

2. Use that same SystemRequestDetails instance for both:
- The binaryDao.read(idElement, srd, true) collision check
- The binaryDao.update(binary, srd) write operation
